### PR TITLE
Make redirects from GitHub work again by allowing HTTP Redirects

### DIFF
--- a/tasmotizer.py
+++ b/tasmotizer.py
@@ -361,6 +361,7 @@ class ProcessDialog(QDialog):
         self._action_widgets['download'].setValue(recv//total*100)
 
     def download_bin(self):
+        self.nrBinFile.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
         self.nrBinFile.setUrl(QUrl(self.file_path))
         self.bin_reply = self.nam.get(self.nrBinFile)
         self.bin_reply.readyRead.connect(self.appendBinFile)


### PR DESCRIPTION
Presently the URL included in the `firmwareURL.py` file is on GitHub. In order to download this file, the code should follow HTTP Redirects. (i.e. from `https://github.com/G4lile0/tinyGS/releases/download/2103201/firmware_2103201-OTA.bin` to this long url `https://github-releases.githubusercontent.com/224729087/ed...`).

Simply setting `QNetworkRequest.FollowRedirectsAttribute` to `True` does exactly this. A one line change.
